### PR TITLE
feat: added outputs for release candidate and extended life support versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       salt-versions: ${{ steps.get-salt-versions.outputs.salt-versions }}
+      salt-versions-els: ${{ steps.get-salt-versions.outputs.salt-versions-els }}
+      salt-versions-rc: ${{ steps.get-salt-versions.outputs.salt-versions-rc }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - id: get-salt-versions
@@ -23,13 +25,18 @@ jobs:
       - run: |
           echo "::notice ::Latest Salt version: ${{ steps.get-salt-versions.outputs.salt-latest }}"
           echo "::notice ::Supported Salt versions: ${{ steps.get-salt-versions.outputs.salt-versions }}"
+          echo "::notice ::Salt versions on extended life support: ${{ steps.get-salt-versions.outputs.salt-versions-els }}"
+          echo "::notice ::Salt release candidate versions: ${{ steps.get-salt-versions.outputs.salt-versions-rc }}"
   show-salt-versions:
     name: Show Salt versions
     needs: gsv
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
+        version:
+          - ${{ fromJSON(needs.gsv.outputs.salt-versions-els) }}
+          - ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
+          - ${{ fromJSON(needs.gsv.outputs.salt-versions-rc) }}
     steps:
       - run: |
           echo "::notice ::Salt version: $SALT_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,23 @@ outputs:
   salt-versions:
     description: A list of currently supported Salt versions
     value: ${{ steps.get-salt-versions.outputs.salt-versions }}
+  salt-versions-els:
+    description: A list of Salt versions on extended life support
+    value: ${{ steps.get-salt-versions.outputs.salt-versions-els }}
+  salt-versions-rc:
+    description: A list of current Salt release candidate versions
+    value: ${{ steps.get-salt-versions.outputs.salt-versions-rc }}
 runs:
   using: composite
   steps:
     - id: get-salt-versions
       shell: bash
       run: |
-        VERSIONS='["3005.5", "3006.7", "3007.0"]'
+        VERSIONS='["3006.7", "3007.0"]'
+        ELS_VERSIONS='["3004.2", "3005.5"]'
+        RC_VERSIONS='[]'
         echo "salt-versions=$VERSIONS" >> $GITHUB_OUTPUT
+        echo "salt-versions-els=$ELS_VERSIONS" >> $GITHUB_OUTPUT
+        echo "salt-versions-rc=$RC_VERSIONS" >> $GITHUB_OUTPUT
         LATEST=$(echo "$VERSIONS" | jq -r '. | max_by( split(".")|map(tonumber) )')
         echo "salt-latest=$LATEST" >> $GITHUB_OUTPUT


### PR DESCRIPTION
BREAKING CHANGE: unsupported versions of Salt will no longer be included in `salt-versions`
