### PR TITLE
ci(renovate): correct the Salt versioning to pick up new RCs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,16 @@
        ':semanticPrefixFix',
       ],
       schedule: [
-        "* * * * *",
+        '* * * * *',
+      ],
+      versioning: 'loose',
+    },
+    {
+      matchDepNames: [
+        'salt-3008.x',
+      ],
+      extends: [
+        ':automergeDisabled',
       ],
     },
   ],


### PR DESCRIPTION
* disable auto-merging for v3008 so that we can make promote to non-RC version list
